### PR TITLE
Fix warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,6 +32,7 @@ navigation:
     url: https://github.com/AWEEKJ/kiko-now
 
 # Pagination
+gems: [jekyll-paginate]
 paginate: 5
 
 # Includes an icon in the footer for each username you enter
@@ -97,7 +98,7 @@ sass:
   style: :expanded # You might prefer to minify using :compressed
 
 # Use the following plug-ins
-plugins:
+plugins_dir:
   - jekyll-sitemap # Create a sitemap using the official Jekyll sitemap gem
   - jekyll-feed # Create an Atom feed using the official Jekyll feed gem
   - jekyll-paginate


### PR DESCRIPTION
Newer versions of jekyll require the `jekyll-paginate` gem and deprecate `plugins` in favor of `plugins_dir` 