### PR TITLE
Update 404.md

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,4 +1,5 @@
 ---
+permalink: /404.html
 layout: page
 title: 404 - Page not found
 ---

--- a/style.scss
+++ b/style.scss
@@ -75,6 +75,7 @@ p {
 }
 
 a {
+  word-wrap: break-word;
   color: $link-color;
   text-decoration: none;
   cursor: pointer;


### PR DESCRIPTION
## Fix the 404 redirection problem.

* Relative issue: [404.md](https://github.com/aweekj/kiko-now/issues/28)
* Reference: [Creating a custom 404 page for your GitHub Pages site](https://help.github.com/en/articles/creating-a-custom-404-page-for-your-github-pages-site)

## Fix the problem that inline anchor text shown on mobile terminal(Let's say, iPhone 6s, size: 375×667) which looks too long cannot automatically break line, producing a horizontal scroll bar

My fix may surely fix *my own problem*, but it might not be the best practice.

* before: 

![before](https://upload.cc/i1/2019/10/18/SKjAWt.jpg)

* after:

![after](https://upload.cc/i1/2019/10/18/O5XcE7.jpg)